### PR TITLE
Updates dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <jclouds.version>2.3.0</jclouds.version>
-    <slf4j.version>1.7.28</slf4j.version>
+    <jclouds.version>2.6.0</jclouds.version>
+    <slf4j.version>2.0.12</slf4j.version>
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
     <revision>0.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
@@ -41,14 +41,19 @@
       <version>${teragrep.jai_02.version}</version>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.1.0-jre</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.3</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
@@ -68,7 +73,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>11.0.17</version>
+      <version>11.0.20</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -83,34 +88,34 @@
     <dependency>
       <groupId>org.gaul</groupId>
       <artifactId>s3proxy</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.4.0-RC1</version>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.4.0-RC1</version>
+      <version>1.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.4.0-RC1</version>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
-    <finalName>${artifactId}</finalName>
+    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
Notes: 
Guava had to be added explicitly as old version through dependencies would conflict
javax.xml.bind:jaxb-api is deprecated and was changed to jakarta.xml.bind:jakarta.xml.bind-api